### PR TITLE
fix(dockerfile): update 'AS' casing to match 'FROM' keywords

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM rclone/rclone:1.68.1 as rclone
-FROM docker:27.3.1 as docker
+FROM rclone/rclone:1.68.1 AS rclone
+FROM docker:27.3.1 AS docker
 
-FROM alpine:3.20.3 as alpine
+FROM alpine:3.20.3 AS alpine
 
-FROM python:3.12.5 as python
+FROM python:3.12.5 AS python
 RUN python -V > .python_version
 
-FROM ghcr.io/pumbaasdad/poetry:2024-09-07 as poetry
+FROM ghcr.io/pumbaasdad/poetry:2024-09-07 AS poetry
 RUN poetry -V > .poetry_version
 
 FROM ghcr.io/pumbaasdad/poetry:2024-09-07


### PR DESCRIPTION
### Description:
This pull request addresses the `FromAsCasing` warnings in the Dockerfiles by updating the 'as' keyword to 'AS' to ensure casing consistency with the 'FROM' keyword. The warnings that prompted this change are listed below:

     => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)   0.0s
     => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)   0.0s
     => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 4)   0.0s
     => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)   0.0s
     => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)   0.0s

### Changes:
- Updated all occurrences of 'as' to 'AS' where 'FROM' keywords appear in the Dockerfiles to ensure consistent casing.
  
### Impact:
This resolves all `FromAsCasing` warnings during the Docker build process and improves readability by adhering to the recommended casing conventions.

Please review and merge if everything looks good.